### PR TITLE
Fix invalid reference in index and miss-typing

### DIFF
--- a/docs/enums.md
+++ b/docs/enums.md
@@ -71,7 +71,7 @@ By default enum values are represented as Python strings, but Ariadne also suppo
 
 Imagine posts on social site that can have weights like "standard", "pinned" and "promoted":
 
-```python
+```graphql
 type Post {
     weight: PostWeight
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,7 +16,6 @@
       "local-development",
       "asgi",
       "wsgi",
-      "integrations",
       "logging",
       "logo"
     ],


### PR DESCRIPTION
This fixes:
- The 404 page when hitting next [here](https://ariadnegraphql.org/docs/wsgi)
- The 404 page when hitting previous [here](https://ariadnegraphql.org/docs/logging)
- The accidental python highlight when graphql was meant instead