### PR TITLE
Reminds folks about 'make_executable_schema'.

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -81,13 +81,12 @@ def resolve_logout(_, info):
     ...
 ```
 
-### Binding Mutation Resolvers
-
+> **Binding Mutation Resolvers**
 > Recall that resolvers need to be bound to their respective resolvers via the `make_executable_schema` call. If you're following along from the introduction that call will look similar to the following:
-
-```python
-make_executable_schema(type_defs, [query, mutations])
-```
+>
+> ```python
+> make_executable_schema(type_defs, [query, mutations])
+> ```
 
 ## Mutation payloads
 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -81,6 +81,15 @@ def resolve_logout(_, info):
     ...
 ```
 
+### Binding Mutation Resolvers
+
+Recall that resolvers need to be bound to their respective resolvers via the
+`make_executable_schema` call. If you're following along from the introduction
+that call will look similar to the following:
+
+```python
+make_executable_schema(type_defs, [query, mutations])
+```
 
 ## Mutation payloads
 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -83,9 +83,7 @@ def resolve_logout(_, info):
 
 ### Binding Mutation Resolvers
 
-> Recall that resolvers need to be bound to their respective resolvers via the
-> `make_executable_schema` call. If you're following along from the introduction
-> that call will look similar to the following:
+> Recall that resolvers need to be bound to their respective resolvers via the `make_executable_schema` call. If you're following along from the introduction that call will look similar to the following:
 
 ```python
 make_executable_schema(type_defs, [query, mutations])

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -82,6 +82,7 @@ def resolve_logout(_, info):
 ```
 
 > **Binding Mutation Resolvers**
+>
 > Recall that resolvers need to be bound to their respective resolvers via the `make_executable_schema` call. If you're following along from the introduction that call will look similar to the following:
 >
 > ```python

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -83,9 +83,9 @@ def resolve_logout(_, info):
 
 ### Binding Mutation Resolvers
 
-Recall that resolvers need to be bound to their respective resolvers via the
-`make_executable_schema` call. If you're following along from the introduction
-that call will look similar to the following:
+> Recall that resolvers need to be bound to their respective resolvers via the
+> `make_executable_schema` call. If you're following along from the introduction
+> that call will look similar to the following:
 
 ```python
 make_executable_schema(type_defs, [query, mutations])


### PR DESCRIPTION
- I was walking the docs and when I got to mutations I kept running into an error that I could not return a null for a non-nullable field.
  - After some debugging I realized I had not added my mutation resolvers to the schema.
- I think this is a helpful reminder, especially for folks new to Ariadne.