### PR TITLE
Minor edits to top-level docs

### DIFF
--- a/docs/bindables.md
+++ b/docs/bindables.md
@@ -9,14 +9,14 @@ In Ariadne bindables are special types implementing the logic required for *bind
 
 ## Schema validation
 
-Standard bindables provided by the library include validation logic that raises `ValueError` when bindable's GraphQL type is not defined by the schema, is incorrect or missing a field.
+Standard bindables provided by the library include validation logic that raises `ValueError` when a bindable's GraphQL type is not defined by the schema, is incorrect, or missing a field.
 
 
 ## Creating custom bindable
 
-While Ariadne already provides bindables for all GraphQL types, you can also create your own bindables. Potential use cases for custom bindables include be adding abstraction or boiler plate for mutations or some of types used in the schema.
+While Ariadne already provides bindables for all GraphQL types, you can also create your own bindables. Potential use cases for custom bindables include adding an abstraction, or boilerplate for mutations or some types used in the schema.
 
-Custom bindable should extend the [`SchemaBindable`](types-reference.md#schemabindable) base type and define `bind_to_schema` method that will receive single argument, instance of `GraphQLSchema` from [graphql-core-next](https://github.com/graphql-python/graphql-core-next) when on executable schema creation:
+Custom bindables should extend the [`SchemaBindable`](types-reference.md#schemabindable) base type and define the `bind_to_schema` method that will receive a single argument, an instance of `GraphQLSchema` (from [graphql-core-next](https://github.com/graphql-python/graphql-core-next)):
 
 ```python
 from graphql.type import GraphQLSchema
@@ -26,3 +26,5 @@ class MyCustomType(SchemaBindable):
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         pass  # insert custom logic here
 ```
+
+`bind_to_schema` is called during executable schema creation.

--- a/docs/documenting-schema.md
+++ b/docs/documenting-schema.md
@@ -11,7 +11,7 @@ There is now a rich ecosystem of tools built on top of those features.  Some of 
 
 ## GraphQL Playground
 
-Ariadne ships with [GraphQL Playground](https://github.com/prisma/graphql-playground), a popular interative API explorer.
+Ariadne ships with [GraphQL Playground](https://github.com/prisma/graphql-playground), a popular interactive API explorer.
 
 GraphQL Playground allows developers and clients to explore the relationships between types across your schema in addition to reading detail about individual types.
 
@@ -20,7 +20,7 @@ GraphQL Playground allows developers and clients to explore the relationships be
 
 ## Descriptions
 
-GraphQL schema definition language supports a special [description syntax](https://facebook.github.io/graphql/June2018/#sec-Descriptions).  This allows you to provide additional context and information alongside your type definitions, which will be accessible both to developers and API consumers.
+The GraphQL schema definition language supports a special [description syntax](https://facebook.github.io/graphql/June2018/#sec-Descriptions). This allows you to provide additional context and information alongside your type definitions, which will be accessible both to developers and API consumers.
 
 GraphQL descriptions are declared using a format that feels very similar to Python's `docstrings`:
 
@@ -58,7 +58,7 @@ query = '''
 
 The GraphQL specification also defines a programmatic way to learn about a server's schema and documentation.  This is called [introspection](https://graphql.org/learn/introspection/).
 
-The Query type in a GraphQL schema also includes special introspection fields (prefixed with a double underscore) which allow a user or application to ask for information about the schema itself:
+The `Query` type in a GraphQL schema also includes special introspection fields (prefixed with a double underscore) which allow a user or application to ask for information about the schema itself:
 
 ```graphql
 query IntrospectionQuery {

--- a/docs/enums.md
+++ b/docs/enums.md
@@ -34,9 +34,9 @@ def resolve_users(*_, status):
         return get_users(is_banned=True)
 ```
 
-The above example defines a resolver that returns a list of users based on user status, defined using `UserStatus` enumerable from schema.
+The above example defines a resolver that returns a list of users based on user status, defined using the `UserStatus` enumerable from the schema.
 
-Implementing logic validating if `status` value is allowed is not required - this is done on a GraphQL level. This query will produce error:
+Implementing logic validating if the `status` value is allowed is not required - this is done by GraphQL. The below query will produce an error:
 
 ```graphql
 {
@@ -69,7 +69,7 @@ GraphQL failed to find `TEST` in `UserStatus`, and returned error without callin
 
 By default enum values are represented as Python strings, but Ariadne also supports mapping GraphQL enums to custom values.
 
-Imagine posts on social site that can have weights like "standard", "pinned" and "promoted":
+Imagine posts on a social site that can have weights like "standard", "pinned" and "promoted":
 
 ```graphql
 type Post {
@@ -83,7 +83,7 @@ enum PostWeight {
 }
 ```
 
-In the database, the application may store those weights as integers from 0 to 2. Normally, you would have to implement a custom resolver transforming GraphQL representation to the integer but, like with scalars, you would have to remember to use this boiler plate on every use.
+In the database, the application may store those weights as integers from 0 to 2. Normally, you would have to implement a custom resolver transforming GraphQL representation to the integer but, like with scalars, you would have to remember to use this boilerplate on every use.
 
 Ariadne provides an `EnumType` utility class thats allows you to delegate this task to GraphQL server:
 
@@ -100,7 +100,7 @@ class PostWeight(enum.IntEnum):
 post_weight = EnumType("PostWeight", PostWeight)
 ```
 
-Include the `post_weight` instance in list of types passed to your GraphQL server, and it will automatically translate Enums between their GraphQL and Python values.
+Include the `post_weight` instance in the list of types passed to your GraphQL server, and it will automatically translate `Enum`s between their GraphQL and Python values.
 
 Instead of `Enum` you may use `dict`:
 

--- a/docs/error-messaging.md
+++ b/docs/error-messaging.md
@@ -4,7 +4,7 @@ title: Error messaging
 ---
 
 
-If you've experimented with GraphQL, you should be familiar that when things don't go according to plan, GraphQL servers include additional key `errors` to the returned response:
+If you've experimented with GraphQL, you should be familiar that when things don't go according to plan, GraphQL servers include an additional key `errors` in the returned response:
 
 ```json
 {
@@ -41,22 +41,22 @@ type_def = """
 """
 ```
 
-Depending on success or failure, your mutation resolver may return either an `error` message to be displayed to the user, or `user` that has been logged in. Your API result handling logic may then interpret the response based on the content of those two keys, only falling back to the main `errors` key to make sure there wasn't an error in query syntax, connection or application.
+Depending on success or failure, your mutation resolver may return either an `error` message to be displayed to the user, or `user` that has been logged in. Your API result-handling logic may then interpret the response based on the content of those two keys, only falling back to the main `errors` key to make sure there wasn't an error in query syntax, connection or application.
 
 Likewise, your `Query` resolvers may return a requested object or `None` that will then cause a message such as "Requested item doesn't exist or you don't have permission to see it" to be displayed to the user in place of the requested resource.
 
 
 ## Debugging errors
 
-By default individual `errors` elements contain very limited amount of information about errors occurring inside the resolvers, forcing developer to search application's logs for details about possible error's causes.
+By default individual `errors` elements contain a very limited amount of information about errors occurring inside the resolvers, forcing a developer to search an application's logs for details about the error's possible causes.
 
-Developer experience can be improved by including the `debug=True` in the list of arguments passed to Ariadne's `GraphQL` object:
+Developer experience can be improved by including `debug=True` in the list of arguments passed to Ariadne's `GraphQL` object:
 
 ```python
 app = GraphQL(schema, debug=True)
 ```
 
-This will result in each error having additional `exception` key containing both complete traceback, and current context for which the error has occurred:
+This will result in each error having an additional `exception` key containing both a complete stacktrace and current context for which the error has occurred:
 
 ```json
 {
@@ -99,13 +99,13 @@ This will result in each error having additional `exception` key containing both
 
 ## Replacing default error formatter
 
-Default error formatter used by Ariadne performs following tasks:
+The default error formatter used by Ariadne performs the following tasks:
 
-* Formats error by using it's `formatted` property.
+* Formats error by using its `formatted` property.
 * Unwraps `GraphQL` error by accessing its `original_error` property.
-* If unwrapped error is available and `debug` argument is set to `True`, update already formatted error to also include `extensions` entry with `exception` dictionary containing `traceback` and `context`.
+* If the unwrapped error is available and the `debug` argument is set to `True`, update the already formatted error to also include an `extensions` entry with an `exception` dictionary containing `stacktrace` and `context`.
 
-If you wish to change or customize this behavior, you can set custom function in `error_formatter` of `GraphQL` object:
+If you wish to change or customize this behavior, you can define a custom function in the `error_formatter` argument to a `GraphQL` object:
 
 ```python
 from ariadne import format_error

--- a/docs/file-uploads.md
+++ b/docs/file-uploads.md
@@ -8,13 +8,13 @@ Ariadne implements the [GraphQL multipart request specification](https://github.
 
 ## Enabling file uploads
 
-To enable file uploads on your server, define new scalar named `Upload` in your schema:
+To enable file uploads on your server, define new a scalar named `Upload` in your schema:
 
 ```graphql
 scalar Upload
 ```
 
-Next, import `upload_scalar` from `ariadne` package and use it during executable schema creation:
+Next, import `upload_scalar` from `ariadne` package and use it during the creation of your executable schema:
 
 ```python
 from ariadne import make_executable_schema, upload_scalar
@@ -35,7 +35,7 @@ type Mutation {
 
 ## Limitations
 
-Default `Upload` scalar is write-only scalar that supports only accessing the value that was passed through the `variables`. It is not possible to use it as return value for GraphQL field or set its value in GraphQL Query:
+The default `Upload` scalar is a write-only scalar that supports only accessing the value that was passed through the `variables`. It is not possible to use it as return value for a GraphQL field or set its value in a GraphQL Query:
 
 ```graphql
 type User {
@@ -55,21 +55,21 @@ mutation {
 
 ## Implementation differences
 
-Python value returned by `Upload` scalar is not standardized and depends on your technology stack:
+The Python value returned by the `Upload` scalar is not standardized and depends on your technology stack:
 
 
 ### `ariadne.asgi`
 
-ASGI application is based on [Starlette](https://starlette.io) and hence uploaded files are instances of [`UploadFile`](https://www.starlette.io/requests/#request-files).
+Ariadne's ASGI support is based on [Starlette](https://starlette.io) and hence uploaded files are instances of [`UploadFile`](https://www.starlette.io/requests/#request-files).
 
 
 ### `ariadne.wsgi`
 
-WSGI application uses the `cgi` module from Python's standard library that represents uploaded files as instances of [`FieldStorage`](https://docs.python.org/3/library/cgi.html#using-the-cgi-module).
+Ariadne's WSGI support uses the `cgi` module from Python's standard library that represents uploaded files as instances of [`FieldStorage`](https://docs.python.org/3/library/cgi.html#using-the-cgi-module).
 
 > Data in `FieldStorage` is not guaranteed to represent an uploaded file.
 
 
 ### `ariadne.contrib.django`
 
-Django integration uses `request.FILES` to obtain uploaded files. Depending on file uploads configuration in your Django project, the files are instances of [`UploadedFile`](https://docs.djangoproject.com/en/2.2/ref/files/uploads/) or one of its subclasses.
+Ariadne's Django integration uses `request.FILES` to obtain uploaded files. Depending on file uploads configuration in your Django project, the files are instances of [`UploadedFile`](https://docs.djangoproject.com/en/2.2/ref/files/uploads/) or one of its subclasses.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -4,13 +4,7 @@ title: Interface types
 ---
 
 
-An `interface` is an abstract GraphQL type that defines a certain set of fields.
-Any other type that contains the same set of fields is said to *implement* that
-`interface`. Types that implement an `interface` are not limited by it. In other
-words, a type can implement an `interface`'s fields as well as additional fields.
-The key point is that a type must implement **at least** the fields of an
-`interface` in order for the schema to be correct.
-
+An `interface` is an abstract GraphQL type that defines a certain set of fields.  Any other type that contains the same set of fields is said to *implement* that `interface`. Types that implement an `interface` are not limited by it. In other words, a type can implement an `interface`'s fields as well as additional fields.  The key point is that a type must implement **at least** the fields of an `interface` in order for the schema to be correct.  
 
 ## Interface example
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -4,14 +4,19 @@ title: Interface types
 ---
 
 
-Interface is an abstract GraphQL type that defines certain set of fields and requires other types *implementing* it to also define same fields in order for schema to be correct.
+An `interface` is an abstract GraphQL type that defines a certain set of fields.
+Any other type that contains the same set of fields is said to *implement* that
+`interface`. Types that implement an `interface` are not limited by it. In other
+words, a type can implement an `interface`'s fields as well as additional fields.
+The key point is that a type must implement **at least** the fields of an
+`interface` in order for the schema to be correct.
 
 
 ## Interface example
 
-Consider an application implementing a search function. Search can return items of different type, like `Client`, `Order` or `Product`. For each result it displays a short summary text that is a link leading to a page containing the item's details.
+Consider an application implementing a search function. Search can return items of different types, like `Client`, `Order` or `Product`. For each result it displays a short summary text that is a link leading to a page containing the item's details.
 
-An `Interface` can be defined in schema that forces those types to define the `summary` and `url` fields:
+An `Interface` can be defined in the schema that forces those types to define the `summary` and `url` fields:
 
 ```graphql
 interface SearchResult {
@@ -45,9 +50,9 @@ type Product implements SearchResult {
 }
 ```
 
-GraphQL standard requires that every type implementing the `Interface` also explicitly defines fields from the interface. This is why the `summary` and `url` fields repeat on all types in the example.
+The GraphQL standard requires that every type implementing the `Interface` also explicitly defines fields from the interface. This is why the `summary` and `url` fields repeat on all types in the example.
 
-Like with the union, the `SearchResult` interface will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of a GraphQL type, or `None` if the received type is incorrect:
+Like with the `Union`, the `SearchResult` interface will also need a special resolver called a *type resolver*. This resolver will be called with an object returned from a field resolver and the current context. It should return a string containing the name of a GraphQL type, or `None` if the received type is incorrect:
 
 ```python
 def resolve_search_result_type(obj, *_):
@@ -83,7 +88,7 @@ from .graphql import resolve_search_result_type
 search_result = InterfaceType("SearchResult", resolve_search_result_type)
 ```
 
-Lastly, your `InterfaceType` instance should be passed to `make_executable_schema` together with other types:
+Lastly, your `InterfaceType` instance should be passed to `make_executable_schema` together with your other types:
 
 ```python
 schema = make_executable_schema(type_defs, [query, search_result])
@@ -92,9 +97,9 @@ schema = make_executable_schema(type_defs, [query, search_result])
 
 ## Field resolvers
 
-Ariadne's `InterfaceType` instances can optionally be used to set resolvers on implementing types fields.
+Ariadne's `InterfaceType` instances can optionally be used to set resolvers on implementing types' fields.
 
-`SearchResult` interface from previous section implements two fields: `summary` and `url`. If resolver implementation for those fields is same for multiple types implementing the interface, `InterfaceType` instance can be used to set those resolvers for those fields:
+The `SearchResult` interface from the previous section implements two fields: `summary` and `url`. If the resolver implementation for those fields is same for multiple types implementing the interface, the `InterfaceType` instance can be used to set those resolvers for those fields:
 
 ```python
 @search_result.field("summary")
@@ -107,11 +112,11 @@ def resolve_url(obj, *_):
     return obj.get_absolute_url()
 ```
 
-`InterfaceType` extends the [ObjectType](resolvers.md), so `set_field` and `set_alias` are also available:
+`InterfaceType` extends the [ObjectType](resolvers.md) class, so `set_field` and `set_alias` are also available:
 
 ```python
 search_result.set_field("summary", resolve_summary)
 search_result.alias("url", "absolute_url")
 ```
 
-> `InterfaceType` assigns the resolver to a field only if that field has no resolver already set. This is different from `ObjectType` that sets resolvers fields if field already has other resolver set.
+> `InterfaceType` assigns the resolver to a field only if that field doesn't already have a resolver set. This is different from an `ObjectType` that can set a resolver to a field even if the field already has another resolver set.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -37,7 +37,7 @@ The `type Query { }` block declares the type, `hello` is the field definition, `
 ## Validating schema
 
 Ariadne provides the `gql` utility function to validate schema. It that takes a
-single argument: a GraphQL string, like the following example.
+single argument, a GraphQL string, like the following example:
 
 ```python
 from ariadne import gql

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -48,8 +48,7 @@ type_defs = gql("""
 """)
 ```
 
-`gql` validates the schema and raises a descriptive `GraphQLSyntaxError`, if
-there is an issue, or returns the original unmodified string if it is correct.
+`gql` validates the schema and raises a descriptive `GraphQLSyntaxError`, if there is an issue, or returns the original unmodified string if it is correct.
 
 
 If we try to run the above code now, we will get an error pointing to incorrect syntax within our `type_defs` declaration:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,7 +8,7 @@ Welcome to Ariadne!
 
 This guide will introduce you to the basic concepts behind creating GraphQL APIs, and show how Ariadne helps you to implement them with just a little Python code.
 
-At the end of this guide you will have your own simple GraphQL API accessible through the browser, implementing a single field that returns a "Hello" message along with a client's user agent.
+At the end of this page you will have your own simple GraphQL API accessible through the browser, implementing a single field that returns a "Hello" message along with a client's user agent.
 
 Make sure that you've installed Ariadne using `pip install ariadne`, and that you have your favorite code editor open and ready.
 
@@ -19,7 +19,7 @@ First, we will describe what data can be obtained from our API.
 
 In Ariadne this is achieved by defining Python strings with content written in [Schema Definition Language](https://graphql.github.io/learn/schema/) (SDL), a special language for declaring GraphQL schemas.
 
-We will start by defining the special type `Query` that GraphQL services use as entry point for all reading operations. Next, we will specify a single field on it, named `hello`, and define that it will return a value of type `String`, and that it will never return `null`.
+We will start by defining the special type `Query` that GraphQL services use as an entry point for all reading operations. Next, we will specify a single field, named `hello`, and define that it will return a value of type `String`, and that it will never return `null`.
 
 Using the SDL, our `Query` type definition will look like this:
 
@@ -36,7 +36,8 @@ The `type Query { }` block declares the type, `hello` is the field definition, `
 
 ## Validating schema
 
-Ariadne provides tiny `gql` utility function that takes single argument: GraphQL string, validates it and raises descriptive `GraphQLSyntaxError`, or returns the original unmodified string if its correct:
+Ariadne provides the `gql` utility function to validate schema. It that takes a
+single argument: a GraphQL string, like the following example.
 
 ```python
 from ariadne import gql
@@ -48,7 +49,11 @@ type_defs = gql("""
 """)
 ```
 
-If we try to run the above code now, we will get an error pointing to our incorrect syntax within our `type_defs` declaration:
+`gql` validates the schema and raises a descriptive `GraphQLSyntaxError`, if
+there is an issue, or returns the original unmodified string if it is correct.
+
+
+If we try to run the above code now, we will get an error pointing to incorrect syntax within our `type_defs` declaration:
 
 ```
 graphql.error.syntax_error.GraphQLSyntaxError: Syntax Error: Expected :, found Name
@@ -69,7 +74,7 @@ The resolvers are functions mediating between API consumers and the application'
 
 We want our API to greet clients with a "Hello (user agent)!" string. This means that the `hello` field has to have a resolver that somehow finds the client's user agent, and returns a greeting message from it.
 
-At its simplest, resolver is a function that returns a value:
+At its simplest, a resolver is a function that returns a value:
 
 ```python
 def resolve_hello(*_):
@@ -80,9 +85,22 @@ The above code is perfectly valid, with a minimal resolver meeting the requireme
 
 Real-world resolvers are rarely that simple: they usually read data from some source such as a database, process inputs, or resolve value in the context of a parent object. How should our basic resolver look to resolve a client's user agent?
 
-In Ariadne every field resolver is called with at least two arguments: `obj` parent object, and the query's execution `info` that usually contains the `context` attribute that is GraphQL's way of passing additional information from the application to its query resolvers.
+In Ariadne every field resolver is called with at least two arguments: the
+query's parent object, and the query's execution `info` that usually contains
+a `context` attribute. The `context` is GraphQL's way of passing additional
+information from the application to its query resolvers.
 
-The default GraphQL server implementation provided by Ariadne defines `info.context` as Python `dict` containing a single key named `request` containing a request object. We can use this in our resolver:
+> In the above example, note the `*_` argument in the resolver's method signature.
+> The underscore is a convention used in many languages (including Python) to
+> indicate a variable that will not be used. The asterisk prefix is Python syntax
+> that informs the method it should expect a variable-length argument list. In
+> effect, the above example is throwing away any arguments passed to the resolver.
+> We've used that here, to simplify the example so that you can focus on its
+> purpose.
+
+The default GraphQL server implementation provided by Ariadne defines
+`info.context` as a Python `dict` containing a single key named `request`
+containing a request object. We can use this in our resolver:
 
 ```python
 def resolve_hello(_, info):
@@ -127,9 +145,15 @@ You pass it your type definitions and resolvers that you want to use:
 schema = make_executable_schema(type_defs, query)
 ```
 
-In Ariadne the process of adding the Python logic to GraphQL schema is called *binding to schema*, and special types that can be passed to the `make_executable_schema` second argument are called *bindables*. `QueryType` introduced earlier is one of many *bindables* provided by Ariadne that developers will use when creating their GraphQL APIs. Next chapters will
+In Ariadne the process of adding the Python logic to GraphQL schema is called
+*binding to schema*, and special types that can be passed to
+`make_executable_schema`'s second argument are called *bindables*. `QueryType`
+(introduced earlier) is one of many *bindables* provided by Ariadne that
+developers will use when creating their GraphQL APIs.
 
-In our first API we are passing only single instance to the `make_executable_schema`, but most of your future APIs will likely pass list of bindables instead, for example:
+In our first API we passed only a single bindable to the
+`make_executable_schema`, but most of your future APIs will likely pass a list
+of bindables instead, for example:
 
 ```python
 make_executable_schema(type_defs, [query, user, mutations, fallback_resolvers])
@@ -140,7 +164,7 @@ make_executable_schema(type_defs, [query, user, mutations, fallback_resolvers])
 
 ## Testing the API
 
-Now we have everything we need to finish our API, with the missing only piece being the http server that would receive the HTTP requests, execute GraphQL queries and return responses.
+Now we have everything we need to finish our API, with the only missing piece being the HTTP server that would receive the HTTP requests, execute GraphQL queries and return responses.
 
 Use an ASGI server like [uvicorn](http://www.uvicorn.org/), [daphne](https://github.com/django/daphne/), or [hypercorn](https://pgjones.gitlab.io/hypercorn/) to serve your application:
 
@@ -156,9 +180,9 @@ from ariadne.asgi import GraphQL
 app = GraphQL(schema, debug=True)
 ```
 
-Run your script with `uvicorn myscript:app` (remember to replace `myscript.py` with the name of your file!). If all is well, you will see a message telling you that the simple GraphQL server is running on the http://127.0.0.1:8000. Open this link in your web browser.
+Run your script with `uvicorn myscript:app` (remember to replace `myscript.py` with the name of your file!). If all is well, you will see a message telling you that the simple GraphQL server is running at http://127.0.0.1:8000. Open this link in your web browser.
 
-You will see the GraphQL Playground, the open source API explorer for GraphQL APIs. You can enter `{ hello }` query on the left, press the big, bright "run" button, and see the result on the right:
+You will see the GraphQL Playground, the open source API explorer for GraphQL APIs. You can enter a `{ hello }` query on the left, press the big, bright "run" button, and see the result on the right:
 
 ![Your first Ariadne GraphQL in action!](assets/hello-world.png)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -50,7 +50,6 @@ type_defs = gql("""
 
 `gql` validates the schema and raises a descriptive `GraphQLSyntaxError`, if there is an issue, or returns the original unmodified string if it is correct.
 
-
 If we try to run the above code now, we will get an error pointing to incorrect syntax within our `type_defs` declaration:
 
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -36,8 +36,7 @@ The `type Query { }` block declares the type, `hello` is the field definition, `
 
 ## Validating schema
 
-Ariadne provides the `gql` utility function to validate schema. It that takes a
-single argument, a GraphQL string, like the following example:
+Ariadne provides the `gql` utility function to validate schema. It that takes a single argument, a GraphQL string, like the following example:
 
 ```python
 from ariadne import gql
@@ -85,18 +84,9 @@ The above code is perfectly valid, with a minimal resolver meeting the requireme
 
 Real-world resolvers are rarely that simple: they usually read data from some source such as a database, process inputs, or resolve value in the context of a parent object. How should our basic resolver look to resolve a client's user agent?
 
-In Ariadne every field resolver is called with at least two arguments: the
-query's parent object, and the query's execution `info` that usually contains
-a `context` attribute. The `context` is GraphQL's way of passing additional
-information from the application to its query resolvers.
+In Ariadne every field resolver is called with at least two arguments: the query's parent object, and the query's execution `info` that usually contains a `context` attribute. The `context` is GraphQL's way of passing additional information from the application to its query resolvers.
 
-> In the above example, note the `*_` argument in the resolver's method signature.
-> The underscore is a convention used in many languages (including Python) to
-> indicate a variable that will not be used. The asterisk prefix is Python syntax
-> that informs the method it should expect a variable-length argument list. In
-> effect, the above example is throwing away any arguments passed to the resolver.
-> We've used that here, to simplify the example so that you can focus on its
-> purpose.
+> In the above example, note the `*_` argument in the resolver's method signature. The underscore is a convention used in many languages (including Python) to indicate a variable that will not be used. The asterisk prefix is Python syntax that informs the method it should expect a variable-length argument list. In effect, the above example is throwing away any arguments passed to the resolver.  We've used that here, to simplify the example so that you can focus on its purpose.
 
 The default GraphQL server implementation provided by Ariadne defines
 `info.context` as a Python `dict` containing a single key named `request`
@@ -151,9 +141,7 @@ In Ariadne the process of adding the Python logic to GraphQL schema is called
 (introduced earlier) is one of many *bindables* provided by Ariadne that
 developers will use when creating their GraphQL APIs.
 
-In our first API we passed only a single bindable to the
-`make_executable_schema`, but most of your future APIs will likely pass a list
-of bindables instead, for example:
+In our first API we passed only a single bindable to the `make_executable_schema`, but most of your future APIs will likely pass a list of bindables instead, for example:
 
 ```python
 make_executable_schema(type_defs, [query, user, mutations, fallback_resolvers])

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -134,11 +134,7 @@ You pass it your type definitions and resolvers that you want to use:
 schema = make_executable_schema(type_defs, query)
 ```
 
-In Ariadne the process of adding the Python logic to GraphQL schema is called
-*binding to schema*, and special types that can be passed to
-`make_executable_schema`'s second argument are called *bindables*. `QueryType`
-(introduced earlier) is one of many *bindables* provided by Ariadne that
-developers will use when creating their GraphQL APIs.
+In Ariadne the process of adding the Python logic to GraphQL schema is called *binding to schema*, and special types that can be passed to `make_executable_schema`'s second argument are called *bindables*. `QueryType` (introduced earlier) is one of many *bindables* provided by Ariadne that developers will use when creating their GraphQL APIs.
 
 In our first API we passed only a single bindable to the `make_executable_schema`, but most of your future APIs will likely pass a list of bindables instead, for example:
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,7 +4,7 @@ title: Logging
 ---
 
 
-Ariadne logs all errors using default `ariadne` logger. To define custom logger instead, pass its name to `logger` option:
+Ariadne logs all errors using default the `ariadne` logger. To define a custom logger instead, pass its name to the `logger` argument when instantiating your application:
 
 ```python
 from ariadne.wsgi import GraphQL
@@ -13,7 +13,7 @@ from .schema import schema
 app = GraphQL(schema, logger="admin.graphql")
 ```
 
-`logger` option is supported by following functions and objects:
+The `logger` argument is supported by following functions and objects:
 
 - `ariadne.graphql`
 - `ariadne.graphql_sync`

--- a/docs/modularization.md
+++ b/docs/modularization.md
@@ -9,13 +9,13 @@ Ariadne allows you to spread your GraphQL API implementation over multiple files
 
 ## Defining schema in `.graphql` files
 
-Recommended way to define schema is by using the `.graphql` files. This approach offers certain advantages:
+The recommended way to define schema is by using `.graphql` files. This approach offers certain advantages:
 
 - First class support from developer tools like [Apollo GraphQL plugin](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) for VS Code.
 - Easier cooperation and sharing of schema design between frontend and backend developers.
 - Dropping whatever python boilerplate code was used for SDL strings.
 
-To load schema from file or directory, you can use the `load_schema_from_path` utility provided by the Ariadne:
+To load schema from a file or directory, you can use the `load_schema_from_path` utility provided by the Ariadne:
 
 ```python
 from ariadne import load_schema_from_path
@@ -41,7 +41,7 @@ The above app won't be able to execute any queries but it will allow you to brow
 
 ## Defining schema in multiple modules
 
-Because Ariadne expects `type_defs` to be either string or list of strings, it's easy to split types across many string variables in many modules:
+Because Ariadne expects `type_defs` to be either a string or list of strings, it's easy to split types across many string variables in many modules:
 
 ```python
 query = """

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -4,8 +4,7 @@ title: Mutations
 ---
 
 
-All the previous examples in this documentation have dealt with the `Query` root
-type and reading data. What about creating, updating or deleting data?
+All the previous examples in this documentation have dealt with the `Query` root type and reading data. What about creating, updating or deleting data?
 
 Enter the `Mutation` type, `Query`'s sibling that GraphQL servers use to implement functions that change application state.
 
@@ -87,11 +86,7 @@ def resolve_logout(_, info):
 
 ## Mutation payloads
 
-The `login` and `logout` mutations introduced earlier in this guide work, but
-give very limited feedback to the client: they return either `False` or `True`.
-The application could use additional information like an error message that
-could be displayed in the interface if the mutation request fails, or a
-user state updated after a mutation completed.
+The `login` and `logout` mutations introduced earlier in this guide work, but give very limited feedback to the client: they return either `False` or `True`.  The application could use additional information like an error message that could be displayed in the interface if the mutation request fails, or a user state updated after a mutation completed.
 
 In GraphQL this is achieved by making mutations return special *payload* types containing additional information about the result, such as errors or current object state:
 

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -15,9 +15,9 @@ class FormResolver:
         ...
 ```
 
-`obj` is a value returned by a parent resolver. If the resolver is a *root resolver* (it belongs to the field defined on `Query`, `Mutation` or `Subscription`) and GraphQL server implementation doesn't explicitly define value for this field, the value of this argument will be `None`.
+`obj` is a value returned by a parent resolver. If the resolver is a *root resolver* (it belongs to the field defined on `Query`, `Mutation` or `Subscription`) and the GraphQL server implementation doesn't explicitly define value for this field, the value of this argument will be `None`.
 
-`info` is the instance of a `GraphQLResolveInfo` object specific for this field and query. It defines a special `context` attribute that contains any value that GraphQL server provided for resolvers on the query execution. Its type and contents are application-specific, but it is generally expected to contain application-specific data such as authentication state of the user or http request.
+`info` is the instance of a `GraphQLResolveInfo` object specific for this field and query. It defines a special `context` attribute that contains any value that GraphQL server provided for resolvers on the query execution. Its type and contents are application-specific, but it is generally expected to contain application-specific data such as authentication state of the user or an HTTP request.
 
 > `context` is just one of many attributes that can be found on `GraphQLResolveInfo`, but it is by far the most commonly used one. Other attributes enable developers to introspect the query that is currently executed and implement new utilities and abstractions, but documenting that is out of Ariadne's scope. If you are interested, you can find the list of all attributes [here](https://github.com/graphql-python/graphql-core-next/blob/v1.0.5/graphql/type/definition.py#L487).
 
@@ -26,7 +26,7 @@ class FormResolver:
 
 A resolver needs to be bound to a valid type's field in the schema in order to be used during the query execution.
 
-To bind resolvers to schema, Ariadne uses a special `ObjectType` class that is initialized with single argument - name of the type defined in the schema:
+To bind resolvers to schema, Ariadne uses a special `ObjectType` class that is initialized with a single argument: the name of the type defined in the schema:
 
 ```python
 from ariadne import ObjectType
@@ -52,7 +52,7 @@ def resolve_hello(*_):
     return "Hello!"
 ```
 
-`@query.field` decorator is non-wrapping - it simply registers a given function as a resolver for specified field and then returns it as it is. This makes it easy to test or reuse resolver functions between different types or even APIs:
+The `@query.field` decorator is non-wrapping - it simply registers a given function as a resolver for the specified field and then returns it as it is. This makes it easy to test or reuse resolver functions between different types or even APIs:
 
 ```python
 user = ObjectType("User")
@@ -78,7 +78,7 @@ user.set_field("email", resolve_email_with_permission_check)
 
 ## Handling arguments
 
-If GraphQL field specifies any arguments, those argument values will be passed to the resolver as keyword arguments:
+If a GraphQL field specifies any arguments, those argument values will be passed to the resolver as keyword arguments:
 
 ```python
 type_def = """
@@ -96,7 +96,7 @@ def resolve_holidays(*_, year=None):
     return Calendar.get_all_holidays()
 ```
 
-If a field argument is marked as required (by following type with `!`, eg. `year: Int!`), you can skip the `=None` in your `kwarg`:
+If a field argument is marked as required (by following its type with `!`, eg. `year: Int!`), you can skip the `=None` in your `kwarg`:
 
 ```python
 @query.field("holidays")
@@ -137,9 +137,9 @@ from .resolvers import resolvers
 schema = make_executable_schema(type_defs, resolvers + [fallback_resolvers])
 ```
 
-The above example creates executable schema using types and resolvers imported from other modules, but it also adds `fallback_resolvers` to the list of bindables that should be used in creation of the schema.
+The above example creates an executable schema using types and resolvers imported from other modules, but it also adds `fallback_resolvers` to the list of bindables that should be used in creation of the schema.
 
-Resolvers set by `fallback_resolvers` don't perform any case conversion and simply seek the attribute named in the same way as the field they are bound to using "default resolver" strategy described in the next chapter.
+Resolvers set by `fallback_resolvers` don't perform any case conversion and simply seek the attribute named in the same way as the field they are bound to using the "default resolver" strategy described in the next chapter.
 
 If your schema uses JavaScript convention for naming its fields (as do all schema definitions in this guide) you may want to instead use the `snake_case_fallback_resolvers` that converts field name to Python's `snake_case` before looking it up on the object:
 
@@ -156,7 +156,7 @@ schema = make_executable_schema(type_defs, resolvers + [snake_case_fallback_reso
 
 Both `ObjectType.alias` and fallback resolvers use an Ariadne-provided default resolver to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -4,9 +4,9 @@ title: Subscriptions
 ---
 
 
-Let's introduce a third type of operation. While queries offer a way to query a server once, subscriptions offer a way for the server to notify the client each time new data is available and that no other data will be available for the given request.
+Let's introduce a third type of operation. While queries offer a way to query a server once, subscriptions offer a way for the server to notify the client each time new data is available.
 
-This is where the `Subscription` type comes useful. It's similar to `Query` but as each subscription remains an open channel you can send anywhere from zero to millions of responses over its lifetime.
+This is where the `Subscription` type is useful. It's similar to `Query` but as each subscription remains an open channel you can send anywhere from zero to millions of responses over its lifetime.
 
 > Because of their nature, subscriptions are only possible to implement in asynchronous servers that implement the WebSockets protocol.
 >
@@ -17,7 +17,7 @@ This is where the `Subscription` type comes useful. It's similar to `Query` but 
 
 ## Defining subscriptions
 
-In schema definition subscriptions look similar to queries:
+In schema definitions subscriptions look similar to queries:
 
 ```graphql
 type Query {
@@ -31,8 +31,9 @@ type Subscription {
 
 This example contains:
 
-- `Query` type with single unused field. GraphQL considers empty type an syntax error and requires API to always define `Query` type.
-- `Subscription` type with a single field: `counter` that returns a number.
+- `Query` type with single unused field. GraphQL considers an empty type a syntax error and requires an API to always define a `Query` type.
+    - For this example, we're focusing on `Subscription`s so we define a bare bones `Query` type.
+- `Subscription` type with a single field, `counter`, that returns a number.
 
 When defining subscriptions you can use all of the features of the schema such as arguments, input and output types.
 
@@ -60,7 +61,7 @@ def counter_resolver(count, info):
 
 Note that the resolver consumes the same type (in this case `int`) that the generator yields.
 
-Each time our source yields a response, its getting sent to our resolver. The above implementation counts from zero to four, each time waiting for one second before yielding a value.
+Each time our source yields a response, it's getting sent to our resolver. The above implementation counts from zero to four, each time waiting for one second before yielding a value.
 
 The resolver increases each number by one before passing them to the client so the client sees the counter progress from one to five.
 
@@ -90,7 +91,7 @@ async def counter_generator(
 
 ## Complete example
 
-For reference here is a complete example of the GraphQL API that supports subscription:
+For reference here is a complete example of the GraphQL API that supports a subscription:
 
 ```python
 import asyncio

--- a/docs/unions.md
+++ b/docs/unions.md
@@ -44,7 +44,7 @@ type MutationPayload {
 }
 ```
 
-Your union will also need a special resolver called a *type resolver*. This resolver will we called with an object returned from a field resolver and the current context.
+Your union will also need a special resolver called a *type resolver*. This resolver will be called with an object returned from a field resolver and the current context.
 It should return a string containing the name of a GraphQL type, or `None` if the received type is incorrect:
 
 ```python

--- a/docs/unions.md
+++ b/docs/unions.md
@@ -44,7 +44,8 @@ type MutationPayload {
 }
 ```
 
-Your union will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of an GraphQL type, or `None` if received type is incorrect:
+Your union will also need a special resolver called a *type resolver*. This resolver will we called with an object returned from a field resolver and the current context.
+It should return a string containing the name of a GraphQL type, or `None` if the received type is incorrect:
 
 ```python
 def resolve_error_type(obj, *_):
@@ -57,7 +58,7 @@ def resolve_error_type(obj, *_):
 
 > Returning `None` from this resolver will result in `null` being returned for this field in your query's result. If field is not nullable, this will cause the GraphQL query to error.
 
-Ariadne relies on dedicated `UnionType` class for bindinding this function to Union in your schema:
+Ariadne relies on the dedicated `UnionType` class for binding this function to `Union`s in your schema:
 
 ```python
 from ariadne import UnionType
@@ -69,7 +70,7 @@ def resolve_error_type(obj, *_):
     ...
 ```
 
-If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the `UnionType` with it as second argument:
+If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the `UnionType` with it as the second argument:
 
 ```python
 from ariadne import UnionType
@@ -78,7 +79,7 @@ from .graphql import resolve_error_type
 error = UnionType("Error", resolve_error_type)
 ```
 
-Lastly, your `UnionType` instance should be passed to `make_executable_schema` together will other types:
+Lastly, your `UnionType` instance should be passed to `make_executable_schema` together with your other types:
 
 ```python
 schema = make_executable_schema(type_defs, [query, error])
@@ -89,7 +90,7 @@ schema = make_executable_schema(type_defs, [query, error])
 
 Every type in GraphQL has a special `__typename` field that is resolved to a string containing the type's name.
 
-Including this field in your query may simplify implementation of result handling logic in your client:
+Including this field in your query may simplify implementation of result-handling logic in your client:
 
 ```graphql
 query getFeed {


### PR DESCRIPTION
- Includes typo and grammar edits for all the top-level docs currently found under the **Docs** header.
- Adds or rearranges some of the context for topics to clarify the scope and direction of the tutorials/examples.