### PR TITLE
Update released docs to also include fixed Django Channels example

### DIFF
--- a/website/versioned_docs/version-0.5.0/django-integration.md
+++ b/website/versioned_docs/version-0.5.0/django-integration.md
@@ -93,7 +93,7 @@ Ariadne's [ASGI application](asgi.md) can be used together with [Django Channels
 from ariadne.asgi import GraphQL
 from channels.http import AsgiHandler
 from channels.routing import URLRouter
-from django.urls import path
+from django.urls import path, re_path
 
 
 schema = ...
@@ -101,7 +101,7 @@ schema = ...
 
 application = URLRouter([
     path("graphql/", GraphQL(schema, debug=True)),
-    path("", AsgiHandler),
+    re_path(r"", AsgiHandler),
 ])
 ```
 


### PR DESCRIPTION
This PR fixes Django channels example in public docs, so fix will be visible without need for releasing new version.

Ref: #22