### PR TITLE
Add docs for schema directives

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -441,6 +441,287 @@ def serialize_datetime(value):
 - - - - -
 
 
+## `SchemaDirectiveVisitor`
+
+```python
+SchemaDirectiveVisitor()
+```
+
+Base class for implementing [schema directives](schema-directives.md).
+
+
+### Attributes
+
+#### `args`
+
+`dict` with arguments passed to the directive.
+
+
+#### `name`
+
+`str` with name of the directive in the schema.
+
+
+#### `schema`
+
+Instance of the `GraphQLSchema`, in which this directive is used.
+
+
+### Methods
+
+#### `visit_argument_definition`
+
+```python
+SchemaDirectiveVisitor.visit_argument_definition(argument, field, object_type)
+```
+
+Called during the executable schema creation for directives supporting the `ARGUMENT_DEFINITION` location set on schema fields arguments:
+
+```graphql
+directive @example on ARGUMENT_DEFINITION
+
+type Mutation {
+    rotateToken(token: String @example): String
+}
+```
+
+Takes following arguments:
+
+- `argument` - an instance of the `GraphQLArgument`.
+- `field` -  an instance of the `GraphQLField`.
+- `object_type` - an instance of the `GraphQLObjectType` or `GraphQLInterfaceType`.
+
+Must return an instance of the `GraphQLArgument`.
+
+
+#### `visit_enum`
+
+```python
+SchemaDirectiveVisitor.visit_enum(enum)
+```
+
+Called during the executable schema creation for directives supporting the `ENUM` location set on enums:
+
+```graphql
+directive @example on ENUM
+
+enum ErrorType @example {
+    NOT_FOUND
+    PERMISSION_DENIED
+    EXPIRED
+}
+```
+
+Takes single argument, an instance `GraphQLEnumType`.
+
+Must return an instance of the `GraphQLEnumType`.
+
+
+#### `visit_enum_value`
+
+```python
+SchemaDirectiveVisitor.visit_enum_value(value, enum_type)
+```
+
+Called during the executable schema creation for directives supporting the `ENUM_VALUE` location set on enum values:
+
+```graphql
+directive @example on ENUM
+
+enum ErrorType {
+    NOT_FOUND
+    PERMISSION_DENIED @example
+    EXPIRED
+}
+```
+
+Takes two arguments:
+
+- `value` - an instance the `GraphQLEnumValue`.
+- `enum_type` - instance of the `GraphQLEnumType` to which this value belongs.
+
+Must return an instance of the `GraphQLEnumValue`.
+
+
+#### `visit_field_definition`
+
+```python
+SchemaDirectiveVisitor.visit_field_definition(field, object_type)
+```
+
+Called during the executable schema creation for directives supporting the `FIELD_DEFINITION` location set on objects and interfaces fields:
+
+```graphql
+directive @example on FIELD_DEFINITION
+
+type User {
+    id: ID
+    username: String @example
+}
+
+interface Searchable {
+    document: String @example
+}
+```
+
+Takes two arguments:
+
+- `field` - an instance the `GraphQLField`.
+- `object_type` - an instance of the `GraphQLObjectType` or `GraphQLInterfaceType` to which this field belongs.
+
+Must return an instance of the `GraphQLField`.
+
+
+#### `visit_input_field_definition`
+
+```python
+SchemaDirectiveVisitor.visit_input_field_definition(field, object_type)
+```
+
+Called during the executable schema creation for directives supporting the `INPUT_FIELD_DEFINITION` location set on inputs fields:
+
+```graphql
+directive @example on INPUT_FIELD_DEFINITION
+
+input UserInput {
+    username: String @example
+    email: String
+}
+```
+
+Takes two arguments:
+
+- `field` - an instance the `GraphQLInputField`.
+- `object_type` - an instance of the `GraphQLInputObjectType` to which this field belongs.
+
+Must return an instance of the `GraphQLInputField`.
+
+
+#### `visit_input_object`
+
+```python
+SchemaDirectiveVisitor.visit_input_object(object_)
+```
+
+Called during the executable schema creation for directives supporting the `INPUT_OBJECT` location set on input types:
+
+```graphql
+directive @example on INPUT_OBJECT
+
+input UserInput @example {
+    username: String
+    email: String
+}
+```
+
+Takes single argument, an instance `GraphQLInputObjectType`.
+
+Must return an instance of the `GraphQLInputObjectType`.
+
+
+#### `visit_interface`
+
+```python
+SchemaDirectiveVisitor.visit_interface(interface)
+```
+
+Called during the executable schema creation for directives supporting the `INTERFACE` location set on interfaces:
+
+```graphql
+directive @example on INTERFACE
+
+interface Searchable @example {
+    document: String
+}
+```
+
+Takes single argument, an instance `GraphQLInterfaceType`.
+
+Must return an instance of the `GraphQLInterfaceType`.
+
+
+#### `visit_object`
+
+```python
+SchemaDirectiveVisitor.visit_object(object_)
+```
+
+Called during the executable schema creation for directives supporting the `OBJECT` location set on objects:
+
+```graphql
+directive @example on OBJECT
+
+type User @example {
+    id: ID
+    username: String
+}
+```
+
+Takes single argument, an instance `GraphQLObjectType`.
+
+Must return an instance of the `GraphQLObjectType`.
+
+
+#### `visit_scalar`
+
+```python
+SchemaDirectiveVisitor.visit_scalar(scalar)
+```
+
+Called during the executable schema creation for directives supporting the `SCALAR` location set on scalars:
+
+```graphql
+directive @example on SCALAR
+
+scalar Datetime @example
+```
+
+Takes single argument, an instance `GraphQLScalarType`.
+
+Must return an instance of the `GraphQLScalarType`.
+
+
+#### `visit_schema`
+
+```python
+SchemaDirectiveVisitor.visit_schema(schema)
+```
+
+Called during the executable schema creation for directives supporting the `SCHEMA` location set on schema:
+
+```graphql
+directive @example on SCHEMA
+
+schema @example {
+    query: Query
+}
+```
+
+Takes single argument, an instance of current `GraphQLSchema`. Should mutate this instance in place - returning anything from this method causes an `ValueError` to be raised.
+
+
+#### `visit_union`
+
+```python
+SchemaDirectiveVisitor.visit_union(union)
+```
+
+Called during the executable schema creation for directives supporting the `UNION` location set on unions:
+
+```graphql
+directive @example on UNION
+
+union SearchResult = User | Thread @example
+```
+
+Takes single argument, an instance `GraphQLUnionType`.
+
+Must return an instance of the `GraphQLUnionType`.
+
+
+- - - - -
+
+
 ## `SnakeCaseFallbackResolversSetter`
 
 ```python
@@ -946,15 +1227,33 @@ Raises [`GraphQLFileSyntaxError`](exceptions-reference.md#graphqlfilesyntaxerror
 ## `make_executable_schema`
 
 ```python
-def make_executable_schema(type_defs, bindables=None)
+def make_executable_schema(type_defs, bindables=None, *, directives=None)
 ```
 
-Takes two arguments:
-
-- `type_defs` - string or list of strings with valid GraphQL types definitions.
-- `bindables` - [bindable or list of bindables](bindables.md) with Python logic to add to schema. *Optional*.
+Construct executable schema - GraphQL schema against which queries can be executed.
 
 Returns `GraphQLSchema` instance that can be used to run queries on.
+
+
+### Required arguments
+
+#### `type_defs`
+
+string or list of strings with valid GraphQL types definitions.
+
+
+### Optional arguments
+
+#### `bindables`
+
+[Bindable or list of bindables](bindables.md) with Python logic to add to schema.
+
+
+### Configuration options
+
+#### `directives`
+
+`dict` that maps schema directives to their Python implementations. See [schema directives documentation](schema-directives.md) for more information and examples.
 
 
 - - - - -

--- a/docs/schema-directives.md
+++ b/docs/schema-directives.md
@@ -1,0 +1,115 @@
+---
+id: schema-directives
+title: Schema directives
+---
+
+Schema directives are special annotations that API developer may use to change or extend query executor's behaviour for selected elements of the schema. Those annotations are defined using dedicated syntax and then consumed during the executable schema creation by Ariadne.
+
+
+## Defining schema directives
+
+Schema directive definition begins with `directive` keyword. This keyword is followed with the name prefixed with ampersand, optional list of arguments and list locations for which this directive may be applied on.
+
+Example directive that changes behaviour of schema field could be defined as such:
+
+```graphql
+directive @example on FIELD_DEFINITION
+```
+
+If directive takes any arguments, those can be defined after its name using same syntax that fields use:
+
+```graphql
+directive @example(arg1: String, arg2: Int!) on FIELD_DEFINITION
+```
+
+In case when directive may be used in more than one location, locations should be separated using the pipe sign:
+
+```graphql
+directive @example on OBJECT | FIELD_DEFINITION
+```
+
+Location may be any of following:
+
+- `SCHEMA`
+- `SCALAR`
+- `OBJECT`
+- `FIELD_DEFINITION`
+- `ARGUMENT_DEFINITION`
+- `INTERFACE`
+- `UNION`
+- `ENUM`
+- `ENUM_VALUE`
+- `INPUT_OBJECT`
+- `INPUT_FIELD_DEFINITION`
+
+
+## Applying directives to schema items
+
+```graphql
+type User @mydirective {
+    id: ID
+    username: String
+}
+
+type Thread {
+
+}
+```
+
+
+## Implementing schema directive behaviour
+
+In Ariadne, schema directive behaviour is implemented by extending `ariadne.SchemaDirectiveVisitor` base class. 
+
+
+## Example: `datetime` format
+
+Following example implements schema directive that formats Python `datetime` object returned by field's resolver.
+
+First, add directive definition to your schema:
+
+```graphql
+directive @date(format: String) on FIELD_DEFINITION
+```
+
+Next, create Python implementation for the directive that defines the `visit_field_definition` method:
+
+```python
+from ariadne import SchemaDirectiveVisitor, default_field_resolver
+
+
+class DateDirective(SchemaDirectiveVisitor):
+    def visit_field_definition(self, field, object_type):
+        date_format = self.args.get("format")
+        original_resolver = field.resolve or default_field_resolver
+
+        def resolve_formatted_date(obj, info, **kwargs):
+            result = original_resolver(obj, info, **kwargs)
+            if result is None:
+                return None
+
+            if date_format:
+                return result.strftime(date_format)
+
+            return result.isoformat()
+
+        field.resolve = resolve_formatted_date
+        return field
+```
+
+Finally, use `directives` option of `make_executable_schema` to attach the behaviour implemented by `DateDirective` with `date` directive definied by schema:
+
+```python
+schema = make_executable_schema(type_defs, resolvers, directives={"date": DateDirective})
+```
+
+You can now update your schema and use your `@date` directive to format dates returned by your API:
+
+```graphql
+type Article {
+    id: ID
+    title: String
+    text: String
+    createdAt: String @date(format: "%Y-%m-%d")
+}
+```

--- a/docs/schema-directives.md
+++ b/docs/schema-directives.md
@@ -3,7 +3,7 @@ id: schema-directives
 title: Schema directives
 ---
 
-Schema directives are special annotations that API developer may use to change or extend query executor's behaviour for selected elements of the schema. Those annotations are defined using dedicated syntax and then consumed during the executable schema creation by Ariadne.
+Schema directives are special annotations that developers can use to change or extend behaviour for selected elements in the schema. Those annotations are defined using dedicated syntax and then consumed during the executable schema creation.
 
 
 ## Defining schema directives
@@ -45,24 +45,39 @@ Location may be any of following:
 
 ## Applying directives to schema items
 
+To apply schema directive to the schema item, simply follow its definition with an ampersand and directive name:
+
 ```graphql
-type User @mydirective {
+directive @adminonly on FIELD_DEFINITION
+
+type User {
     id: ID
     username: String
-}
-
-type Thread {
-
+    ipAddress: String @adminonly
 }
 ```
 
+If directive accepts any arguments, those can be passed to it like this:
+
+```graphql
+directive @needsPermission(permission: String) on FIELD_DEFINITION
+
+type User {
+    id: ID
+    username: String
+    ipAddress: String @needsPermission(permission: "ADMIN")
+}
+```
+
+Values passed to directive arguments follow same validation logic that values passed to fields in GraphQL queries do, except those errors will be raised at the time of calling the `make_executable_schema`.
+
 
 ## Implementing schema directive behaviour
+ą
+In Ariadne, schema directive behaviour is implemented by extending the [`ariadne.SchemaDirectiveVisitor`](api-reference.md#schemadirectivevisitor) base class. 
 
-In Ariadne, schema directive behaviour is implemented by extending `ariadne.SchemaDirectiveVisitor` base class. 
 
-
-## Example: `datetime` format
+### Example: `datetime` format
 
 Following example implements schema directive that formats Python `datetime` object returned by field's resolver.
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,6 +14,7 @@
       "documenting-schema",
       "modularization",
       "bindables",
+      "schema-directives",
       "local-development",
       "logging"
     ],


### PR DESCRIPTION
Schema directives are quite a biggie documentation-wise, so I expect this PR will take some time to wrap up.

### TODO

- [x] Document theory behind schema directives
- [x] Provide few examples for custom schema directives
- [x] Write API docs for `SchemaDirectiveVisitor`
- [x] Document `directives` option on `make_executable_schema`