### PR TITLE
Fix confusion on snake_case and camelCase

### DIFF
--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -106,7 +106,7 @@ def resolve_holidays(*_, year):
     return Calendar.get_all_holidays()
 ```
 
-> **Note:** You can decorate your resolvers with [`convert_kwargs_to_snake_case`](api-reference.md#convert_kwargs_to_snake_case) to convert arguments and inputs names from `snakeCase` to `camel_case`.
+> **Note:** You can decorate your resolvers with [`convert_kwargs_to_snake_case`](api-reference.md#convert_kwargs_to_snake_case) to convert arguments and inputs names from `camelCase` to `snake_case`.
 
 
 ## Aliases


### PR DESCRIPTION
> ...from `snakeCase` to `camel_case`.

I assume you want to convert to snake_case, given the API reference. At first glance, it looks like you are doing the opposite, converting snake_case to camelCase.

Feel free to swap them, incase I am wrong.