### PR TITLE
Update docs for recent extensions API changes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1199,8 +1199,6 @@ See [`graphql`](#graphql) required arguments.
 
 See [`graphql`](#graphql) configuration options
 
-> This function doesn't support `extensions` option.
-
 
 - - - - -
 

--- a/docs/apollo-tracing.md
+++ b/docs/apollo-tracing.md
@@ -22,4 +22,4 @@ app = GraphQL(
 )
 ```
 
-> **Note:** If using WSGI, use `ApolloTracingExtensionSync` in place of `ApolloTracingExtension`.
+> **Note:** If you are using WSGI, use `ApolloTracingExtensionSync` in place of `ApolloTracingExtension`.

--- a/docs/asgi.md
+++ b/docs/asgi.md
@@ -39,10 +39,3 @@ $ uvicorn myasgi:application
 #### `keepalive`
 
 If given a number of seconds, will send "keepalive" packets to the client in an attempt to prevent the connection from being dropped due to inactivity.
-
-
-#### `extensions`
-
-[Extensions](extensions.md) to use during query processing.
-
-Can be list of classes extending [`Extension`](types-reference.md#extension), or callable that will be called with single argument (HTTP request representation specific to the web stack used) that should return `None` or list of those.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -78,7 +78,7 @@ class QueryExecutionTimeExtension(Extension):
     def request_started(self, context):
         self.start_timestamp = time.perf_counter_ns()
 
-    def request_finished(self, context, error=None):
+    def request_finished(self, context):
         self.end_timestamp = time.perf_counter_ns()
 ```
 
@@ -101,10 +101,10 @@ class QueryExecutionTimeExtension(Extension):
     def request_started(self, context):
         self.start_timestamp = time.perf_counter_ns()
 
-    def request_finished(self, context, error=None):
+    def request_finished(self, context):
         self.end_timestamp = time.perf_counter_ns()
 
-    def format(self):
+    def format(self, context):
         if self.start_timestamp and self.end_timestamp:
             return {
                 "execution": self.start_timestamp - self.end_timestamp
@@ -114,7 +114,7 @@ class QueryExecutionTimeExtension(Extension):
 
 ## WSGI extension implementation
 
-To implement extensions for WSGI, the `resolve` function in your Extension cannot be `async`. An `ExtensionSync` class is provided which implements a synchronous `resolve`.
+If your GraphQL server is deployed using WSGI, you can't use `Extension` as base class for your extensions. Use `ExtensionSync` which implements a synchronous `resolve` instead:
 
 ```python
 from ariadne.types import ExtensionSync as Extension

--- a/docs/open-tracing.md
+++ b/docs/open-tracing.md
@@ -63,4 +63,4 @@ app = GraphQL(
 )
 ```
 
-> **Note:** If using WSGI, use `opentracing_extension_sync` in place of `opentracing_extension`.
+> **Note:** If you are using WSGI, use `opentracing_extension_sync` in place of `opentracing_extension`.

--- a/docs/types-reference.md
+++ b/docs/types-reference.md
@@ -71,12 +71,12 @@ Base class for [extensions](extensions.md).
 #### `format`
 
 ```python
-Extension.format()
+Extension.format(context)
 ```
 
 Allows extensions to add data to `extensions` key in GraphQL response.
 
-Should return dict.
+Should return a `dict`.
 
 ##### Example
 
@@ -87,7 +87,7 @@ from datetime import datetime
 
 
 class TimestampExtension(Extension):
-    def format(self):
+    def format(self, context):
         return {"timestamp": datetime.now().isoformat()}
 ```
 
@@ -107,7 +107,7 @@ Result:
 #### `has_errors`
 
 ```python
-Extension.has_errors(errors)
+Extension.has_errors(errors, context)
 ```
 
 Called with `list` of errors that occurred during query process. Not called if no errors were raised. Errors may come from `validation`, query parsing or query execution.
@@ -116,7 +116,7 @@ Called with `list` of errors that occurred during query process. Not called if n
 #### `request_finished`
 
 ```python
-Extension.request_finished(context, error=None)
+Extension.request_finished(context)
 ```
 
 Called when query processing finishes.
@@ -140,6 +140,14 @@ Extension.resolve(next_, parent, info[, **kwargs])
 Used as middleware for fields resolver. Takes special `next_` argument that is next resolver in resolvers chain that should be called.
 
 Everything else is same as with regular [resolvers](#resolver).
+
+
+- - - - -
+
+
+## `ExtensionSync`
+
+Synchronous counterpart of the [`Extension`](#extension). All hooks are the same, but `resolve` hook can't be asynchronous.
 
 
 - - - - -


### PR DESCRIPTION
This PR updates extensions docs to reflect changes to extensions API introduced in 0.7:

- Extensions can be used in synchronous servers
- Extension hooks are called with `context`