### PR TITLE
Change ampersand to `@`

### DIFF
--- a/docs/schema-directives.md
+++ b/docs/schema-directives.md
@@ -8,7 +8,7 @@ Schema directives are special annotations that developers can use to change or e
 
 ## Defining schema directives
 
-Schema directive definition begins with `directive` keyword. This keyword is followed with the name prefixed with ampersand, optional list of arguments and list locations for which this directive may be applied on.
+Schema directive definition begins with `directive` keyword. This keyword is followed with the name prefixed with `@`, optional list of arguments and list locations for which this directive may be applied on.
 
 Example directive that changes behaviour of schema field could be defined as such:
 
@@ -45,7 +45,7 @@ Location may be any of following:
 
 ## Applying directives to schema items
 
-To apply schema directive to the schema item, simply follow its definition with an ampersand and directive name:
+To apply schema directive to the schema item, simply follow its definition with an `@` and directive name:
 
 ```graphql
 directive @adminonly on FIELD_DEFINITION


### PR DESCRIPTION
Reading through the docs, I noticed some accidental confusion between the at symbol (`@`) and the ampersand (`&`). In order to match the code examples, these changes replace the two instances of "ampersand" with `@`.

Let me know if there are any prose changes you'd like here, or feel free to go ahead and edit the PR 🙂 I experimented with writing out "the at symbol" instead of using `@`, but it felt a little clunky.

Thanks for making Ariadne! 😄