### PR TITLE
Remove word "recursively" from documentation for load_schema_from_path

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1212,7 +1212,7 @@ def load_schema_from_path(path)
 Loads GraphQL schema from `path` using different strategy depending on `path`'s type:
 
 - If `path` is single file, reads it.
-- If `path` is directory, walks it recursively loading all `.graphql` files within it.
+- If `path` is directory, walks it loading all `.graphql` files within it.
 
 Files are validated using the same logic that [`gql`](#gql) uses, concatenated into single string and returned.
 


### PR DESCRIPTION
The load_schema_from_path function does not descend into subdirectories of the path provided, so this word is misleading