### PR TITLE
fix accidental substitution

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -284,4 +284,4 @@ input PollOptionInput {
 
 Lastly, take note that inputs are not specific to mutations. You can create inputs to implement complex filtering in your `Query` fields.
 
-> **Note:** you can decorate your resolvers with [`convert_kwargs_to_snake_case`](api-reference.md#convert_kwargs_to_snake_case) to convert arguments and inputs names from `snakeCase` to `camel_case`.
+> **Note:** you can decorate your resolvers with [`convert_kwargs_to_snake_case`](api-reference.md#convert_kwargs_to_snake_case) to convert arguments and inputs names from `camelCase` to `snake_case`.


### PR DESCRIPTION
`convert_kwargs_to_snake_case` converts from `camelCase` to `snakeCase`, not the other way around.