### PR TITLE
Add documentation for introspection parameter on graphql and graphql_sync

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1102,7 +1102,21 @@ type_defs = gql("""
 ## `graphql`
 
 ```python
-async def graphql(schema, data, *, root_value=None, context_value=None, logger=None, debug=False, introspection=True, validation_rules, error_formatter, extensions=None, middleware, **kwargs)
+async def graphql(
+    schema,
+    data,
+    *,
+    root_value=None,
+    context_value=None,
+    logger=None,
+    debug=False,
+    introspection=True,
+    validation_rules,
+    error_formatter,
+    extensions=None,
+    middleware,
+    **kwargs
+)
 ```
 
 Asynchronously executes query against the schema.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1185,7 +1185,19 @@ List of middleware that should be used during the query execution.
 ## `graphql_sync`
 
 ```python
-def graphql(schema, data, *, root_value=None, context_value=None, debug=False, introspection=True, validation_rules, error_formatter, middleware, **kwargs)
+def graphql(
+    schema,
+    data,
+    *,
+    root_value=None,
+    context_value=None,
+    debug=False,
+    introspection=True,
+    validation_rules,
+    error_formatter,
+    middleware,
+    **kwargs
+)
 ```
 
 Synchronously executes query against schema.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1149,6 +1149,7 @@ String with the name of logger that should be used to log GraphQL errors. Defaul
 
 If `True` will cause the server to include debug information in error responses.
 
+
 #### `introspection`
 
 If `False` will prevent clients from introspecting the schema, returning an error in the response.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1166,7 +1166,9 @@ If `True` will cause the server to include debug information in error responses.
 
 #### `introspection`
 
-If `False` will prevent clients from introspecting the schema, returning an error in the response.
+If `False` will prevent clients from introspecting the schema, returning an error when any of introspection fields such as `__schema` are queried.
+
+Disabling introspection will also disable the GraphQL Playground, resulting in error 405 "method not allowed" being returned for GET requests.
 
 
 #### `validation_rules`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1102,7 +1102,7 @@ type_defs = gql("""
 ## `graphql`
 
 ```python
-async def graphql(schema, data, *, root_value=None, context_value=None, logger=None, debug=False, validation_rules, error_formatter, extensions=None, middleware, **kwargs)
+async def graphql(schema, data, *, root_value=None, context_value=None, logger=None, debug=False, introspection=True, validation_rules, error_formatter, extensions=None, middleware, **kwargs)
 ```
 
 Asynchronously executes query against the schema.
@@ -1149,6 +1149,10 @@ String with the name of logger that should be used to log GraphQL errors. Defaul
 
 If `True` will cause the server to include debug information in error responses.
 
+#### `introspection`
+
+If `False` will prevent clients from introspecting the schema, returning an error in the response.
+
 
 #### `validation_rules`
 
@@ -1180,7 +1184,7 @@ List of middleware that should be used during the query execution.
 ## `graphql_sync`
 
 ```python
-def graphql(schema, data, *, root_value=None, context_value=None, debug=False, validation_rules, error_formatter, middleware, **kwargs)
+def graphql(schema, data, *, root_value=None, context_value=None, debug=False, introspection=True, validation_rules, error_formatter, middleware, **kwargs)
 ```
 
 Synchronously executes query against schema.


### PR DESCRIPTION
Corresponding documentation changes for https://github.com/mirumee/ariadne/pull/358

Tried to find all relevant sections to add this information, though if I missed any please let me know.

I feel like this kind of information might also have a place in a `Production` section, where relevant information about pushing an Ariadne app to production might be relevant.