### PR TITLE
I figured out why the python syntax highlighting wasn't working!

### DIFF
--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -264,7 +264,7 @@ def resolve_update_discussion(_, info, discussion, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 

--- a/docs/mutations.md
+++ b/docs/mutations.md
@@ -225,7 +225,7 @@ def resolve_create_discussion(_, info, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 

--- a/website/versioned_docs/version-0.10.0/mutations.md
+++ b/website/versioned_docs/version-0.10.0/mutations.md
@@ -226,7 +226,7 @@ def resolve_create_discussion(_, info, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 
@@ -265,7 +265,7 @@ def resolve_update_discussion(_, info, discussion, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 

--- a/website/versioned_docs/version-0.4.0/mutations.md
+++ b/website/versioned_docs/version-0.4.0/mutations.md
@@ -217,7 +217,7 @@ def resolve_create_discussion(_, info, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 
@@ -256,7 +256,7 @@ def resolve_update_discussion(_, info, discussion, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 

--- a/website/versioned_docs/version-0.6.0/mutations.md
+++ b/website/versioned_docs/version-0.6.0/mutations.md
@@ -226,7 +226,7 @@ def resolve_create_discussion(_, info, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 
@@ -265,7 +265,7 @@ def resolve_update_discussion(_, info, discussion, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 

--- a/website/versioned_docs/version-0.7.0/mutations.md
+++ b/website/versioned_docs/version-0.7.0/mutations.md
@@ -226,7 +226,7 @@ def resolve_create_discussion(_, info, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 
@@ -265,7 +265,7 @@ def resolve_update_discussion(_, info, discussion, input):
     except ValidationError as err:
         return {
             "status": False,
-            "error: err,
+            "error": err,
         }
 ```
 


### PR DESCRIPTION
;)

This occurs multiple times throughout the documentation. This is just one scenario that I caught.