### PR TITLE
Fixing typo in the flask integration code example

### DIFF
--- a/docs/flask-integration.md
+++ b/docs/flask-integration.md
@@ -34,7 +34,7 @@ app = Flask(__name__)
 
 
 @app.route("/graphql", methods=["GET"])
-def graphql_playgroud():
+def graphql_playground():
     # On GET request serve GraphQL Playground
     # You don't need to provide Playground if you don't want to
     # but keep on mind this will not prohibit clients from

--- a/website/versioned_docs/version-0.4.0/flask-integration.md
+++ b/website/versioned_docs/version-0.4.0/flask-integration.md
@@ -35,7 +35,7 @@ app = Flask(__name__)
 
 
 @app.route("/graphql", methods=["GET"])
-def graphql_playgroud():
+def graphql_playground():
     # On GET request serve GraphQL Playground
     # You don't need to provide Playground if you don't want to
     # but keep on mind this will not prohibit clients from


### PR DESCRIPTION
`playgroud` VS `playground`.