### PR TITLE
Update scalars documentation

### DIFF
--- a/docs/scalars.md
+++ b/docs/scalars.md
@@ -245,6 +245,6 @@ money.set_serializer(json_serialize_money)
 money.set_value_parser(json_deserialize_money)
 ```
 
-> **Note:** the previous versions of this document also introduced the `literal_parser`. However in the light of `literal_parser` [reference documentation being incorrect](https://github.com/graphql/graphql-js/issues/2567) and the very usefulness of custom literal parsers [being discussed](https://github.com/graphql/graphql-js/issues/2657) we've decided to don't document it here anymore.
+> **Note:** the previous versions of this document also introduced the `literal_parser`. However in the light of `literal_parser` [reference documentation being incorrect](https://github.com/graphql/graphql-js/issues/2567) and the usefulness of custom literal parsers [being discussed](https://github.com/graphql/graphql-js/issues/2657) we've decided to no longer document it in this section.
 >
 > GraphQL query executor provides default literal parser for all scalars that converts `AST` to Python value then calls scalar's value parser with it, making implementation of custom literal parsers for scalars unnecessary.

--- a/docs/scalars.md
+++ b/docs/scalars.md
@@ -245,6 +245,6 @@ money.set_serializer(json_serialize_money)
 money.set_value_parser(json_deserialize_money)
 ```
 
-> **Note:** the previous versions of this document also introduced the `literal_parser`. However in the light of `literal_parser` [reference documentation being incorrect](https://github.com/graphql/graphql-js/issues/2567) and the usefulness of custom literal parsers [being discussed](https://github.com/graphql/graphql-js/issues/2657) we've decided to no longer document it in this section.
+> **Note:** the previous versions of this document also introduced the `literal_parser`. However in the light of `literal_parser` [reference documentation being incorrect](https://github.com/graphql/graphql-js/issues/2567) and the usefulness of custom literal parsers [being discussed](https://github.com/graphql/graphql-js/issues/2657) we've decided to no longer document it in this article.
 >
 > GraphQL query executor provides default literal parser for all scalars that converts `AST` to Python value then calls scalar's value parser with it, making implementation of custom literal parsers for scalars unnecessary.


### PR DESCRIPTION
Updates scalar documentation to be more truthful and don't tell people to implement `literal_parser` because those are troublesome and offer no advantages over the default literal parser that GraphQL lib uses for all scalars.

Fixes #54