### PR TITLE
provide documentation for django-specific error formatter

### DIFF
--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -131,3 +131,23 @@ type_defs = """
 
 schema = make_executable_schema(type_defs, [date_scalar, datetime_scalar, ...])
 ```
+
+## Error Formatting
+
+Ariadne sets clear expectations for delivery of validation messages and similar server side errors in 
+[Error Messaging](error-messaging.md).  A default formatter with django-specific error handling is provided.
+This formatter also handles djangorestframework's errors if you use that as well.  This can be configured 
+similar to the following:
+
+```python
+from ariadne.contrib.django.format_error import format_graphql_error
+from ariadne.contrib.django.views import GraphQLView
+from django.urls import path
+
+from .schema import schema
+
+urlpatterns = [
+    ...
+    path("graphql/", GraphQLView.as_view(schema=schema, error_formatter=format_graphql_error), name="graphql"),
+]
+```

--- a/docs/error-messaging.md
+++ b/docs/error-messaging.md
@@ -123,3 +123,9 @@ def my_format_error(error: GraphQLError, debug: bool = False) -> dict:
 
 app = GraphQL(schema, error_formatter=my_format_error)
 ```
+
+### Django
+
+A default error formatted that covers a number of django and djangorestframework-specific errors has been provided 
+in `ariadne.contrib.django.format_error.format_graphql_error`.  You can an updated set of constants as a dictionary
+to override messaging.  If not, this file can serve as a helpful starting point for building your own formatter.


### PR DESCRIPTION
Django provides a number of useful exceptions.  Handling them with grace out of the box provides for a faster user onboarding experience.  This is a companion PR to https://github.com/mirumee/ariadne/pull/392