### PR TITLE
docs: fix incorrect name in example code

### DIFF
--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -133,7 +133,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.10.0/resolvers.md
+++ b/website/versioned_docs/version-0.10.0/resolvers.md
@@ -134,7 +134,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.11.0/resolvers.md
+++ b/website/versioned_docs/version-0.11.0/resolvers.md
@@ -134,7 +134,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.4.0/resolvers.md
+++ b/website/versioned_docs/version-0.4.0/resolvers.md
@@ -88,7 +88,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.5.0/resolvers.md
+++ b/website/versioned_docs/version-0.5.0/resolvers.md
@@ -88,7 +88,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.6.0/resolvers.md
+++ b/website/versioned_docs/version-0.6.0/resolvers.md
@@ -88,7 +88,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.7.0/resolvers.md
+++ b/website/versioned_docs/version-0.7.0/resolvers.md
@@ -88,7 +88,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):

--- a/website/versioned_docs/version-0.8.0/resolvers.md
+++ b/website/versioned_docs/version-0.8.0/resolvers.md
@@ -134,7 +134,7 @@ type_def = """
     }
 """
 
-user = ObjectType("Query")
+query = ObjectType("Query")
 
 @query.field("holidays")
 def resolve_holidays(*_, year=None):


### PR DESCRIPTION
Example snippet contains invalid name.

Mistake probably originally caused by copy-pasting.