### PR TITLE
Fix spelling mistake in middleware.md

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -13,7 +13,7 @@ def lowercase_middleware(resolver, obj, info, **args)
 
 > **Note**
 >
-> GraphQL middleware is sometimes confused with the ASGI or WSGI middleware, bit its not the same thing!
+> GraphQL middleware is sometimes confused with the ASGI or WSGI middleware, but its not the same thing!
 
 > **Note**
 >


### PR DESCRIPTION
Simple mistake: `but` was misspelled as `bit`.