### PR TITLE
Expand subscription docs

### DIFF
--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -291,7 +291,7 @@ def context_value(request):
         # request is an instance of WebSocket
         context.update(websocket.scope["connection_params"])
     else:
-        context["token"] = request.META.get("authorization)
+        context["token"] = request.META.get("authorization")
 
     return context
 


### PR DESCRIPTION
Greatly expands subscriptions documentation: documents `on_connect` and `on_disconnect`, connection params, usage of pub-sub library (with Broadcaster), providing simple GraphQL chat example, refusing connections.

Fixes #77 