### PR TITLE
Corrected typos in resolvers.md

### DIFF
--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -90,7 +90,7 @@ schema = make_executable_schema(type_defs, query, user)
 
 > **Note**
 >
-> In previous versions of Ariadne recommended approach to passing multiple bindables to `make_executable_schema` was to combine those into a list:
+> In previous versions of Ariadne, the recommended approach to pass multiple bindables to `make_executable_schema` was to combine those into a list:
 >
 > ```python
 > schema = make_executable_schema(type_defs, [query, user])


### PR DESCRIPTION
Changed:
In previous versions of Ariadne recommended approach to passing multiple bindables to make_executable_schema was to combine those into a list:

To:
In previous versions of Ariadne, the recommended approach to pass multiple bindables to make_executable_schema was to combine those into a list: