### PR TITLE
Add deprecation notice to Django docs

### DIFF
--- a/docs/django-integration.md
+++ b/docs/django-integration.md
@@ -7,6 +7,12 @@ sidebar_label: Django
 
 Ariadne ships with `ariadne.contrib.django` package that should be used as Django app and provides utilities for adding GraphQL server to Django projects.
 
+> **Deprecation notice**
+>
+> `ariadne.contrib.django` has been deprecated and will be removed in future version of Ariadne. It's also not receiving any more features and bug fixes.
+>
+> See [`ariadne_django`](https://github.com/reset-button/ariadne_django) for the drop-in replacement.
+
 
 ## Adding GraphQL API to Django project
 

--- a/website/versioned_docs/version-0.13.0/django-integration.md
+++ b/website/versioned_docs/version-0.13.0/django-integration.md
@@ -8,6 +8,12 @@ original_id: django-integration
 
 Ariadne ships with `ariadne.contrib.django` package that should be used as Django app and provides utilities for adding GraphQL server to Django projects.
 
+> **Deprecation notice**
+>
+> `ariadne.contrib.django` has been deprecated and will be removed in future version of Ariadne. It's also not receiving any more features and bug fixes.
+>
+> See [`ariadne_django`](https://github.com/reset-button/ariadne_django) for the drop-in replacement.
+
 
 ## Adding GraphQL API to Django project
 


### PR DESCRIPTION
We are deprecating Django support in `ariadne.contrib` but we aren't documenting it in the docs, which is bad.

I've updated the docs for Django documentation to mention this.