### PR TITLE
Mention ariadne graphql modules in docs

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -23,9 +23,12 @@ class HomeSplash extends React.Component {
 
     const ShoutOut = () => (
       <div className="shoutout">
-        <a href="https://schemattic.io" target="_blank">
-          🎉 Mirumee presents: <strong>Schemattic.io</strong> - Experiment, mock
-          and share your GraphQL APIs!
+        <a
+          href="https://github.com/mirumee/ariadne-graphql-modules"
+          target="_blank"
+        >
+          🎉 Introducing <strong>Ariadne GraphQL Modules</strong> for sane
+          definition and modularization of large GraphQL schemas!
         </a>
       </div>
     );
@@ -67,7 +70,7 @@ class HomeSplash extends React.Component {
     return (
       <SplashContainer>
         <div className="inner">
-          {/* <ShoutOut /> */}
+          <ShoutOut />
           <Lead />
           <PromoSection>
             <Button href={docUrl("intro.html")}>Get started</Button>

--- a/website/static/css/shoutout.css
+++ b/website/static/css/shoutout.css
@@ -1,6 +1,5 @@
 .shoutout {
-  background-color: #1b9cfc;
-  text-shadow: 0px 0px 3px #19517c;
+  background-color: #fff200;
   border-radius: 8px;
   margin-top: 1rem;
 }
@@ -10,7 +9,7 @@
   .shoutout a:visited {
     display: block;
     padding: 1rem;
-    color: #fff;
+    color: #000;
   }
 
   .shoutout a:hover {

--- a/website/static/css/shoutout.css
+++ b/website/static/css/shoutout.css
@@ -1,5 +1,6 @@
 .shoutout {
-  background-color: #4f5eff;
+  background-color: #1b9cfc;
+  text-shadow: 0px 0px 3px #19517c;
   border-radius: 8px;
   margin-top: 1rem;
 }

--- a/website/versioned_docs/version-0.15/modularization.md
+++ b/website/versioned_docs/version-0.15/modularization.md
@@ -1,5 +1,5 @@
 ---
-id: version-0.15.0-modularization
+id: version-0.15-modularization
 title: Modularization
 original_id: modularization
 ---

--- a/website/versioned_docs/version-0.15/modularization.md
+++ b/website/versioned_docs/version-0.15/modularization.md
@@ -1,6 +1,7 @@
 ---
-id: modularization
+id: version-0.15.0-modularization
 title: Modularization
+original_id: modularization
 ---
 
 


### PR DESCRIPTION
This PR adds shoutout bar to index page and mentions AGM on modularization page in docs:

<img width="1409" alt="Zrzut ekranu 2022-05-12 o 18 26 33" src="https://user-images.githubusercontent.com/750553/168123764-791a21bc-8782-4f37-98c4-73f4e81ae1c2.png">

![Zrzut ekranu 2022-05-12 o 18 29 41](https://user-images.githubusercontent.com/750553/168124069-734bee64-583b-4ce6-8f9d-5d09b5ff0ed5.png)

