### PR TITLE
Fix spelling on the resolvers page

### DIFF
--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -216,7 +216,7 @@ schema = make_executable_schema(type_defs, resolvers, snake_case_fallback_resolv
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/website/versioned_docs/version-0.10.0/resolvers.md
+++ b/website/versioned_docs/version-0.10.0/resolvers.md
@@ -217,7 +217,7 @@ schema = make_executable_schema(type_defs, resolvers, snake_case_fallback_resolv
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core-next` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/website/versioned_docs/version-0.11.0/resolvers.md
+++ b/website/versioned_docs/version-0.11.0/resolvers.md
@@ -217,7 +217,7 @@ schema = make_executable_schema(type_defs, resolvers, snake_case_fallback_resolv
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/website/versioned_docs/version-0.6.0/resolvers.md
+++ b/website/versioned_docs/version-0.6.0/resolvers.md
@@ -159,7 +159,7 @@ schema = make_executable_schema(type_defs, resolvers + [snake_case_fallback_reso
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core-next` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/website/versioned_docs/version-0.7.0/resolvers.md
+++ b/website/versioned_docs/version-0.7.0/resolvers.md
@@ -159,7 +159,7 @@ schema = make_executable_schema(type_defs, resolvers + [snake_case_fallback_reso
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core-next` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 

--- a/website/versioned_docs/version-0.8.0/resolvers.md
+++ b/website/versioned_docs/version-0.8.0/resolvers.md
@@ -205,7 +205,7 @@ schema = make_executable_schema(type_defs, resolvers, snake_case_fallback_resolv
 
 Both `ObjectType.alias` and fallback resolvers use a default resolver provided by `graphql-core-next` library to implement its functionality.
 
-This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If resolved value is callable, its called with arguments that were passed to the resolver field, and its return value is then used instead.
+This resolver takes a target attribute name and (depending if `obj` is a `dict` or not) uses either `obj.get(attr_name)` or `getattr(obj, attr_name, None)` to resolve the value that should be returned. If the resolved value is callable, it is called with arguments that were passed to the resolver field, and its return value is then used instead.
 
 In the below example, both representations of `User` type are supported by the default resolver:
 


### PR DESCRIPTION
Correct "its" to "it is" (it could be "it's" but "it is" is clearer) and add "the".