### PR TITLE
Add docs for websocket/http handlers

### DIFF
--- a/docs/asgi.md
+++ b/docs/asgi.md
@@ -33,9 +33,25 @@ $ uvicorn myasgi:application
 
 ### Configuration options
 
-`GraphQL` takes the same options that [`graphql`](api-reference.md#configuration-options) does, but accepts extra option specific to it:
+`GraphQL` takes the same options that [`graphql`](api-reference.md#configuration-options) does, but accepts extra options specific to it:
 
 
 #### `keepalive`
 
 If given a number of seconds, will send "keepalive" packets to the client in an attempt to prevent the connection from being dropped due to inactivity.
+
+
+#### `http_handler`
+
+Instance of a class extending `ariadne.asgi.handlers.GraphQLHTTPHandler`. Used to handle HTTP requests.
+
+If not set, `ariadne.asgi.handlers.GraphQLHTTPHandler` is used.
+
+
+#### `websocket_handler`
+
+Instance of a class extending `ariadne.asgi.handlers.GraphQLWebsocketHandler`. Used to handle WebSocket connections.
+
+If not set, `GraphQLWSHandler` (implementing [`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws) protocol) is used by default.
+
+See [subscriptions](/subscriptions#subscription-protocols) documentation for more details.

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -18,6 +18,40 @@ This is where the `Subscription` type is useful. It's similar to `Query` but as 
 > **Note:** Ariadne implements [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md) protocol for GraphQL subscriptions.
 
 
+## Subscription protocols
+
+In the world of GraphQL clients, there are two subscription protocols that clients can implement for subscribing to GraphQL server.
+
+
+### `subscriptions-transport-ws`
+
+Default protocol used by Ariadne. Client library for it is still widely used although no it's no longer maintained. It has benefit of being supported by GraphQL-Playground out of the box.
+
+Repo link: [apollographql/subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws)
+
+
+### `graphql-ws`
+
+New protocol that replaced `subscriptions-transport-ws`. Its actively maintained and supported by Apollo Studio Explorer.
+
+Repo link: [enisdenjo/graphql-ws](https://github.com/enisdenjo/graphql-ws)
+
+To make Ariadne use `graphql-ws` protocol for subscriptions, initialize `ariadne.asgi.GraphQL` app with `ariadne.asgi.handlers.GraphQLTransportWSHandler` instance:
+
+```python
+from ariadne.asgi import GraphQL
+from ariadne.asgi.handlers import GraphQLTransportWSHandler
+
+
+graphql_app = GraphQL(
+    schema,
+    websocket_handler=GraphQLTransportWSHandler(),
+)
+```
+
+> **Note:** Name of class implementing `graphql-ws` is not a mistake. The subprotocol used for subscriptions is indeed named [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md).
+
+
 ## Defining subscriptions
 
 In schema definition subscriptions look similar to queries:


### PR DESCRIPTION
In Ariadne 0.16 we are making `asgi.GraphQL()` app more modular, so this PR adds documentation for those new modules API.