### PR TITLE
Add schemattic to the index page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -295,6 +295,10 @@ urlpatterns = [
                   Implement GraphQL schemas of any size using modular approach.
                 </p>
               </a>
+              <a href="https://schemattic.io" target="_blank">
+                <strong>Schemattic</strong>
+                <p>Create, mock and share with others GraphQL APIs.</p>
+              </a>
             </div>
           </div>
         </div>

--- a/website/static/css/home.css
+++ b/website/static/css/home.css
@@ -143,7 +143,7 @@
   display: block;
   margin-bottom: .5em;
 
-  font-size: 2em;
+  font-size: 1.5em;
 }
 
 .homeSeeAlsoGrid a p {


### PR DESCRIPTION
We've created and are maintaining schemattic.io, but we don't really advertise it anywhere.

We we give it a proper treatment in v2 of the website, but for now we will give it a shoutout on Ariadne's index page.